### PR TITLE
fix ldap update user

### DIFF
--- a/service/ildap/user_ildap.go
+++ b/service/ildap/user_ildap.go
@@ -44,7 +44,7 @@ func (x UserService) Add(user *model.User) error {
 // Update 更新资源
 func (x UserService) Update(oldusername string, user *model.User) error {
 	modify := ldap.NewModifyRequest(user.UserDN, nil)
-	modify.Replace("cn", []string{user.Nickname})
+	modify.Replace("cn", []string{user.Username})
 	modify.Replace("sn", []string{oldusername})
 	modify.Replace("businessCategory", []string{user.Departments})
 	modify.Replace("departmentNumber", []string{user.Position})


### PR DESCRIPTION
修复bug 修改用户的时候会在LDAP中误把cn值存为 Nickname，正确值应为 Username

<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献者指南]()。
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**

- 修复bug：修改用户的时候会在LDAP中误把cn值存为 Nickname，正确值应为 Username