### PR TITLE
fix:解决因username为空导致同步失败，解决departments字段长度问题

### DIFF
--- a/logic/a_logic.go
+++ b/logic/a_logic.go
@@ -2,7 +2,6 @@ package logic
 
 import (
 	"fmt"
-
 	"github.com/eryajf/go-ldap-admin/config"
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/public/common"
@@ -255,6 +254,13 @@ func BuildUserData(flag string, remoteData map[string]interface{}) (*model.User,
 		return nil, tools.NewOperationError(err)
 	}
 
+	// 校验username是否为空，username为必填项
+	name := gjson.Get(string(output), fieldRelation["username"]).String()
+	if len(name) == 0 {
+		common.Log.Warnf("%s 该用户未填写username", output)
+		return nil, nil
+	}
+
 	u := &model.User{}
 	for system, remote := range fieldRelation {
 		switch system {
@@ -310,8 +316,10 @@ func ConvertUserData(flag string, remoteData []map[string]interface{}) (users []
 		if err != nil {
 			return nil, err
 		}
-		user.DepartmentId = tools.SliceToString(groupIds, ",")
-		users = append(users, user)
+		if user != nil {
+			user.DepartmentId = tools.SliceToString(groupIds, ",")
+			users = append(users, user)
+		}
 	}
 	return
 }

--- a/model/user.go
+++ b/model/user.go
@@ -13,7 +13,7 @@ type User struct {
 	Mobile        string  `gorm:"type:varchar(15);not null;unique;comment:'手机号'" json:"mobile"`                      // 手机号
 	Avatar        string  `gorm:"type:varchar(255);comment:'头像'" json:"avatar"`                                      // 头像
 	PostalAddress string  `gorm:"type:varchar(255);comment:'地址'" json:"postalAddress"`                               // 地址
-	Departments   string  `gorm:"type:varchar(128);comment:'部门'" json:"departments"`                                 // 部门
+	Departments   string  `gorm:"type:varchar(512);comment:'部门'" json:"departments"`                                 // 部门
 	Position      string  `gorm:"type:varchar(128);comment:'职位'" json:"position"`                                    //  职位
 	Introduction  string  `gorm:"type:varchar(255);comment:'个人简介'" json:"introduction"`                              // 个人简介
 	Status        uint    `gorm:"type:tinyint(1);default:1;comment:'状态:1在职, 2离职'" json:"status"`                     // 状态


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献者指南]()。
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**

1. 因username信息为空导致同步数据错误：https://github.com/eryajf/go-ldap-admin/issues/198
2. 因用户所属部门过多，导致departments字段长度超长：https://github.com/eryajf/go-ldap-admin/issues/199
3. 关于同步信息的等待图标优化：https://github.com/eryajf/go-ldap-admin/issues/197#issuecomment-1517224082
