### PR TITLE
dingtalk包添加按日期范围查询离职员工接口更新

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -121,6 +121,7 @@ dingtalk:
     #- "48456726"   # 需要同步的部门ID
     #- "^61213417"  # 不需要同步的部门ID
   is-update-syncd: false # 当钉钉用户的邮箱，手机号，部门等信息更新之后，是否同步更新，默认为false，如果你不了解这个字段的含义，则不建议开启
+  user-leave-range: 1 #按配置天数查离职时间范围内的用户,为0时不限制
 wecom:
   # 配置获取详细文档参考：http://ldapdoc.eryajf.net/pages/cf1698/
   flag: "wecom" # 作为微信在平台的标识

--- a/config/config.go
+++ b/config/config.go
@@ -169,6 +169,7 @@ type DingTalkConfig struct {
 	UserSyncTime  string   `mapstructure:"user-sync-time" json:"userSyncTime"`
 	DeptList      []string `mapstructure:"dept-list" json:"deptList"`
 	IsUpdateSyncd bool     `mapstructure:"is-update-syncd" json:"isUpdateSyncd"`
+	ULeaveRange   uint     `mapstructure:"user-leave-range" json:"userLevelRange"`
 }
 
 type WeComConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.0
 	github.com/spf13/viper v1.11.0
 	github.com/thoas/go-funk v0.7.0
-	github.com/zhaoyunxing92/dingtalk/v2 v2.0.7-0.20220601083444-173c10c3f835
+	github.com/zhaoyunxing92/dingtalk/v2 v2.1.1-0.20231013102126-c1568b7fbac5
 	go.uber.org/zap v1.19.1
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -436,6 +436,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 github.com/zhaoyunxing92/dingtalk/v2 v2.0.7-0.20220601083444-173c10c3f835 h1:T6/rI54b4nVpQlIDv0iB0hTff4hzlXe63QcBcZ3u73s=
 github.com/zhaoyunxing92/dingtalk/v2 v2.0.7-0.20220601083444-173c10c3f835/go.mod h1:MSvHUbYR94ffuWbJKFb8yHYyHg3qC/kQ3Hqpr6lK5ko=
+github.com/zhaoyunxing92/dingtalk/v2 v2.1.1-0.20231013102126-c1568b7fbac5 h1:Ur2sZLt+zwZeYw3aNi/YhsreTnXqIeM7YrmaSH3obmA=
+github.com/zhaoyunxing92/dingtalk/v2 v2.1.1-0.20231013102126-c1568b7fbac5/go.mod h1:MSvHUbYR94ffuWbJKFb8yHYyHg3qC/kQ3Hqpr6lK5ko=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/logic/dingtalk_logic.go
+++ b/logic/dingtalk_logic.go
@@ -99,7 +99,13 @@ func (d DingTalkLogic) SyncDingTalkUsers(c *gin.Context, req interface{}) (data 
 	}
 
 	// 3.获取钉钉已离职用户id列表
-	userIds, err := dingtalk.GetLeaveUserIds()
+	// 根据配置判断是查全部离职用户还是只查指定时间范围内的离职用户
+	var userIds []string
+	if config.Conf.DingTalk.ULeaveRange == 0 {
+		userIds, err = dingtalk.GetLeaveUserIds()
+	} else {
+		userIds, err = dingtalk.GetLeaveUserIdsDateRange(config.Conf.DingTalk.ULeaveRange)
+	}
 	if err != nil {
 		return nil, tools.NewOperationError(fmt.Errorf("SyncDingTalkUsers获取钉钉离职用户列表失败：%s", err.Error()))
 	}

--- a/public/client/dingtalk/dingtalk.go
+++ b/public/client/dingtalk/dingtalk.go
@@ -173,8 +173,13 @@ func GetLeaveUserIds() ([]string, error) {
 func GetLeaveUserIdsDateRange(pushDays uint) ([]string, error) {
 	var ids []string
 	// 配置值为正数,往前推转为负数
-	startTime := time.Now().AddDate(0, 0, -int(pushDays)).Format("2023-01-01T00:00:00Z")
-	endTime := time.Now().Format("2023-01-01T00:00:00Z")
+	var leaveDays = int(0 - pushDays)
+	now := time.Now()
+	var leaveStartTime = now.AddDate(0, 0, leaveDays)
+	startTime := fmt.Sprintf("%d-%d-%dT%d:%d:%dZ", leaveStartTime.Year(), leaveStartTime.Month(), leaveStartTime.Day(),
+		leaveStartTime.Hour(), leaveStartTime.Minute(), leaveStartTime.Second())
+	endTime := fmt.Sprintf("%d-%d-%dT%d:%d:%dZ", now.Year(), now.Month(), now.Day(),
+		now.Hour(), now.Minute(), now.Second())
 	ReqParm := struct {
 		StartTime  string `json:"startTime"`
 		EndTime    string `json:"endTime"`

--- a/public/client/dingtalk/dingtalk.go
+++ b/public/client/dingtalk/dingtalk.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/eryajf/go-ldap-admin/config"
 	"github.com/eryajf/go-ldap-admin/public/tools"
@@ -15,10 +16,10 @@ import (
 func GetAllDepts() (ret []map[string]interface{}, err error) {
 	depts, err := InitDingTalkClient().FetchDeptList(1, true, "zh_CN")
 	if err != nil {
-			return ret, err
-		}
+		return ret, err
+	}
 	if len(config.Conf.DingTalk.DeptList) == 0 {
-		
+
 		ret = make([]map[string]interface{}, 0)
 		for _, dept := range depts.Dept {
 			ele := make(map[string]interface{})
@@ -102,7 +103,7 @@ func GetAllUsers() (ret []map[string]interface{}, err error) {
 			if err != nil {
 				return nil, err
 			}
-			for _, user := range rsp.DeptDetailUsers {
+			for _, user := range rsp.Page.List {
 				ele := make(map[string]interface{})
 				ele["userid"] = user.UserId
 				ele["unionid"] = user.UnionId
@@ -131,10 +132,10 @@ func GetAllUsers() (ret []map[string]interface{}, err error) {
 				ele["department_ids"] = sourceDeptIds
 				ret = append(ret, ele)
 			}
-			if !rsp.HasMore {
+			if !rsp.Page.HasMore {
 				break
 			}
-			r.Cursor = rsp.NextCursor
+			r.Cursor = rsp.Page.NextCursor
 		}
 	}
 	return
@@ -157,11 +158,48 @@ func GetLeaveUserIds() ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		ids = append(ids, rsp.UserIds...)
-		if rsp.NextCursor == 0 {
+		ids = append(ids, rsp.Result.UserIds...)
+		if rsp.Result.NextCursor == 0 {
 			break
 		}
-		ReqParm.Cursor = rsp.NextCursor
+		ReqParm.Cursor = rsp.Result.NextCursor
+	}
+	return ids, nil
+}
+
+// 官方文档：https://open.dingtalk.com/document/orgapp/query-the-details-of-employees-who-have-left-office
+// GetLeaveUserIdsByDateRange 新接口根据时间范围获取离职人员ID列表
+// GetHrmempLeaveRecordsKey    = "/v1.0/contact/empLeaveRecords"
+func GetLeaveUserIdsDateRange(pushDays uint) ([]string, error) {
+	var ids []string
+	// 配置值为正数,往前推转为负数
+	startTime := time.Now().AddDate(0, 0, -int(pushDays)).Format("2023-01-01T00:00:00Z")
+	endTime := time.Now().Format("2023-01-01T00:00:00Z")
+	ReqParm := struct {
+		StartTime  string `json:"startTime"`
+		EndTime    string `json:"endTime"`
+		NextToken  string `json:"nextToken"`
+		MaxResults int    `json:"maxResults"`
+	}{
+		StartTime:  startTime,
+		EndTime:    endTime,
+		NextToken:  "0",
+		MaxResults: 50,
+	}
+	// 使用新的使用时间范围查询离职人员接口获取离职用户ID
+	for {
+		rsp, err := InitDingTalkClient().GetHrmEmpLeaveRecords(ReqParm.StartTime, ReqParm.EndTime, ReqParm.NextToken, ReqParm.MaxResults)
+		if err != nil {
+			return nil, err
+		}
+		for _, g := range rsp.Records {
+			ids = append(ids, g.UserId)
+		}
+
+		if rsp.NextToken == "0" || rsp.NextToken == "" {
+			break
+		}
+		ReqParm.NextToken = rsp.NextToken
 	}
 	return ids, nil
 }

--- a/public/client/dingtalk/dingtalk.go
+++ b/public/client/dingtalk/dingtalk.go
@@ -174,12 +174,8 @@ func GetLeaveUserIdsDateRange(pushDays uint) ([]string, error) {
 	var ids []string
 	// 配置值为正数,往前推转为负数
 	var leaveDays = int(0 - pushDays)
-	now := time.Now()
-	var leaveStartTime = now.AddDate(0, 0, leaveDays)
-	startTime := fmt.Sprintf("%d-%d-%dT%d:%d:%dZ", leaveStartTime.Year(), leaveStartTime.Month(), leaveStartTime.Day(),
-		leaveStartTime.Hour(), leaveStartTime.Minute(), leaveStartTime.Second())
-	endTime := fmt.Sprintf("%d-%d-%dT%d:%d:%dZ", now.Year(), now.Month(), now.Day(),
-		now.Hour(), now.Minute(), now.Second())
+	startTime := time.Now().AddDate(0, 0, leaveDays).Format("2006-01-02T15:04:05Z")
+	endTime := time.Now().Format("2006-01-02T15:04:05Z")
 	ReqParm := struct {
 		StartTime  string `json:"startTime"`
 		EndTime    string `json:"endTime"`


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [*] 我已阅读并理解[贡献者指南](https://github.com/eryajf/go-ldap-admin/blob/main/CONTRIBUTING.md)。
- [*] 我已检查没有与此请求重复的拉取请求。
- [*] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [*] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写 PR 内容：**

- dingtalk包添加日期范围查询离职员工接口
- dingtalk包2.1.0版本更新部门信息返回结构体更新参数引用
- 本机测试，只同步了昨天离职的一个用户信息，正常构建
- 请审核
![postman](https://github.com/eryajf/go-ldap-admin/assets/52623921/0dd381b3-5ff8-40cb-bd9e-d7355cea9153)
![vscode](https://github.com/eryajf/go-ldap-admin/assets/52623921/ae7d4676-6422-41fb-96db-e9e024e75445)

