### PR TITLE
增加日志请求头和日志清空功能

### DIFF
--- a/controller/operation_log_controller.go
+++ b/controller/operation_log_controller.go
@@ -24,3 +24,11 @@ func (m *OperationLogController) Delete(c *gin.Context) {
 		return logic.OperationLog.Delete(c, req)
 	})
 }
+
+// Clean 清空记录
+func (m *OperationLogController) Clean(c *gin.Context) {
+	req := new(request.OperationLogListReq)
+	Run(c, req, func() (interface{}, interface{}) {
+		return logic.OperationLog.Clean(c, req)
+	})
+}

--- a/logic/operation_log_logic.go
+++ b/logic/operation_log_logic.go
@@ -79,6 +79,7 @@ func (l OperationLogLogic) Clean(c *gin.Context, req interface{}) (data interfac
 		return nil, ReqAssertErr
 	}
 	_ = c
+	fmt.Println(r)
 	err := isql.OperationLog.Clean()
 	if err != nil {
 		return err, nil

--- a/logic/operation_log_logic.go
+++ b/logic/operation_log_logic.go
@@ -21,7 +21,7 @@ func (l OperationLogLogic) List(c *gin.Context, req interface{}) (data interface
 		return nil, ReqAssertErr
 	}
 	_ = c
-
+	fmt.Println(r)
 	// 获取数据列表
 	logs, err := isql.OperationLog.List(r)
 	if err != nil {
@@ -71,4 +71,17 @@ func (l OperationLogLogic) Delete(c *gin.Context, req interface{}) (data interfa
 		return nil, tools.NewMySqlError(fmt.Errorf("删除该改条记录失败: %s", err.Error()))
 	}
 	return nil, nil
+}
+
+func (l OperationLogLogic) Clean(c *gin.Context, req interface{}) (data interface{}, rspError interface{}) {
+	r, ok := req.(*request.OperationLogListReq)
+	if !ok {
+		return nil, ReqAssertErr
+	}
+	_ = c
+	err := isql.OperationLog.Clean()
+	if err != nil {
+		return err, nil
+	}
+	return "操作日志情况完成", nil
 }

--- a/logic/operation_log_logic.go
+++ b/logic/operation_log_logic.go
@@ -74,12 +74,11 @@ func (l OperationLogLogic) Delete(c *gin.Context, req interface{}) (data interfa
 }
 
 func (l OperationLogLogic) Clean(c *gin.Context, req interface{}) (data interface{}, rspError interface{}) {
-	r, ok := req.(*request.OperationLogListReq)
+	_, ok := req.(*request.OperationLogListReq)
 	if !ok {
 		return nil, ReqAssertErr
 	}
 	_ = c
-	fmt.Println(r)
 	err := isql.OperationLog.Clean()
 	if err != nil {
 		return err, nil

--- a/model/request/operation_log_req.go
+++ b/model/request/operation_log_req.go
@@ -5,6 +5,7 @@ type OperationLogListReq struct {
 	Username string `json:"username" form:"username"`
 	Ip       string `json:"ip" form:"ip"`
 	Path     string `json:"path" form:"path"`
+	Method   string `json:"method" form:"method"`
 	Status   int    `json:"status" form:"status"`
 	PageNum  int    `json:"pageNum" form:"pageNum"`
 	PageSize int    `json:"pageSize" form:"pageSize"`

--- a/public/common/init_mysql_data.go
+++ b/public/common/init_mysql_data.go
@@ -649,6 +649,13 @@ func InitData() {
 			Remark:   "批量删除操作日志",
 			Creator:  "系统",
 		},
+		{
+			Method:   "DELETE",
+			Path:     "/log/operation/clean",
+			Category: "log",
+			Remark:   "清空操作日志",
+			Creator:  "系统",
+		},
 	}
 
 	// 5. 将角色绑定给菜单

--- a/routes/operation_log_routes.go
+++ b/routes/operation_log_routes.go
@@ -17,6 +17,7 @@ func InitOperationLogRoutes(r *gin.RouterGroup, authMiddleware *jwt.GinJWTMiddle
 	{
 		operation_log.GET("/operation/list", controller.OperationLog.List)
 		operation_log.POST("/operation/delete", controller.OperationLog.Delete)
+		operation_log.DELETE("/operation/clean", controller.OperationLog.Clean)
 	}
 	return r
 }


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献者指南](https://github.com/eryajf/go-ldap-admin/blob/main/CONTRIBUTING.md)。
- [X] 我已检查没有与此请求重复的拉取请求。
- [X] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [X] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写 PR 内容：**

-  增加操作日志请求头查询
-  清空日志功能
-  增加数据初始化添加接口
-  增加前端相关的代码，后续同步到相关VUE项目

您好，我想参与维护这个项目。目前增加两个功能（前端也已经适配），后续想增加用户登录日志记录 和 相关的Swag 文档 以及相关独立外置的openLDAP的方案

![1](https://github.com/eryajf/go-ldap-admin/assets/46562911/d681709b-58bc-4a4d-bd52-b86c4c7902f8)
![2](https://github.com/eryajf/go-ldap-admin/assets/46562911/4a4ecc7b-1743-4470-8b6f-e387ee69534b)
![3](https://github.com/eryajf/go-ldap-admin/assets/46562911/59556d91-dfd0-4346-be29-78cbab72bc5c)

