### PR TITLE
build: 更新前端资源链接，修复打包错误

### DIFF
--- a/.github/workflows/buildAndPush-binary-to-release.yml
+++ b/.github/workflows/buildAndPush-binary-to-release.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
-          release_url=$(curl -s https://api.github.com/repos/eryajf/go-ldap-admin-ui/releases/latest | grep "browser_download_url" | grep -v 'dist.zip.md5' | cut -d '"' -f 4); wget $release_url && unzip dist.zip && rm dist.zip && mv dist public/static
+          release_url=$(curl -s https://api.github.com/repos/opsre/go-ldap-admin-ui/releases/latest | grep "browser_download_url" | grep -v 'dist.zip.md5' | cut -d '"' -f 4); wget $release_url && unzip dist.zip && rm dist.zip && mv dist public/static
       - uses: wangyoucao577/go-release-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }} # 一个默认的变量，用来实现往 Release 中添加文件

--- a/.github/workflows/go-ci-check.yml
+++ b/.github/workflows/go-ci-check.yml
@@ -12,7 +12,7 @@ jobs:
           go-version: 1.18
       - uses: actions/checkout@v3
       - run: |
-          release_url=$(curl -s https://api.github.com/repos/eryajf/go-ldap-admin-ui/releases/latest | grep "browser_download_url" | grep -v 'dist.zip.md5' | cut -d '"' -f 4); wget $release_url && unzip dist.zip && rm dist.zip && mv dist public/static
+          release_url=$(curl -s https://api.github.com/repos/opsre/go-ldap-admin-ui/releases/latest | grep "browser_download_url" | grep -v 'dist.zip.md5' | cut -d '"' -f 4); wget $release_url && unzip dist.zip && rm dist.zip && mv dist public/static
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: |
-          release_url=$(curl -s https://api.github.com/repos/eryajf/go-ldap-admin-ui/releases/latest | grep "browser_download_url" | grep -v 'dist.zip.md5' | cut -d '"' -f 4); wget $release_url && unzip dist.zip && rm dist.zip && mv dist public/static
+          release_url=$(curl -s https://api.github.com/repos/opsre/go-ldap-admin-ui/releases/latest | grep "browser_download_url" | grep -v 'dist.zip.md5' | cut -d '"' -f 4); wget $release_url && unzip dist.zip && rm dist.zip && mv dist public/static
     - name: Set up Go
       uses: actions/setup-go@v3
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ADD . .
 
 COPY --from=registry.cn-hangzhou.aliyuncs.com/eryajf/docker-compose-wait /wait .
 
-RUN release_url=$(curl -s https://api.github.com/repos/eryajf/go-ldap-admin-ui/releases/latest | grep "browser_download_url" | grep -v 'dist.zip.md5' | cut -d '"' -f 4); wget $release_url && unzip dist.zip && rm dist.zip && mv dist public/static
+RUN release_url=$(curl -s https://api.github.com/repos/opsre/go-ldap-admin-ui/releases/latest | grep "browser_download_url" | grep -v 'dist.zip.md5' | cut -d '"' -f 4); wget $release_url && unzip dist.zip && rm dist.zip && mv dist public/static
 
 RUN sed -i 's@localhost:389@openldap:389@g' /app/config.yml \
     && sed -i 's@host: localhost@host: mysql@g'  /app/config.yml && go build -o go-ldap-admin . && upx -9 go-ldap-admin && upx -9 wait


### PR DESCRIPTION
- 修改了 GitHub Actions 和 Dockerfile 中的前端资源下载链接
- 将链接从 eryajf/go-ldap-admin-ui 更改为 opsre/go-ldap-admin-ui
- 此更改确保了正确获取最新的前端资源进行构建和部署

<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [ ] 我已阅读并理解[贡献者指南](https://github.com/eryajf/go-ldap-admin/blob/main/CONTRIBUTING.md)。
- [ ] 我已检查没有与此请求重复的拉取请求。
- [ ] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [ ] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写 PR 内容：**

-
-
