### PR TITLE
🐛 fix(dingtalk): 修复钉钉部门同步的错误处理和日志记录

### DIFF
--- a/logic/feishu_logic.go
+++ b/logic/feishu_logic.go
@@ -7,7 +7,7 @@ import (
 	"github.com/eryajf/go-ldap-admin/config"
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/public/client/feishu"
-
+	"github.com/eryajf/go-ldap-admin/public/common"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/ildap"
 	"github.com/eryajf/go-ldap-admin/service/isql"
@@ -22,11 +22,15 @@ func (d *FeiShuLogic) SyncFeiShuDepts(c *gin.Context, req interface{}) (data int
 	// 1.获取所有部门
 	deptSource, err := feishu.GetAllDepts()
 	if err != nil {
-		return nil, tools.NewOperationError(fmt.Errorf("获取飞书部门列表失败：%s", err.Error()))
+		errMsg := fmt.Sprintf("获取飞书部门列表失败：%s", err.Error())
+		common.Log.Errorf("SyncFeiShuDepts: %s", errMsg)
+		return nil, tools.NewOperationError(fmt.Errorf(errMsg))
 	}
 	depts, err := ConvertDeptData(config.Conf.FeiShu.Flag, deptSource)
 	if err != nil {
-		return nil, tools.NewOperationError(fmt.Errorf("转换飞书部门数据失败：%s", err.Error()))
+		errMsg := fmt.Sprintf("转换飞书部门数据失败：%s", err.Error())
+		common.Log.Errorf("SyncFeiShuDepts: %s", errMsg)
+		return nil, tools.NewOperationError(fmt.Errorf(errMsg))
 	}
 
 	// 2.将远程数据转换成树
@@ -34,7 +38,13 @@ func (d *FeiShuLogic) SyncFeiShuDepts(c *gin.Context, req interface{}) (data int
 
 	// 3.根据树进行创建
 	err = d.addDepts(deptTree.Children)
+	if err != nil {
+		errMsg := fmt.Sprintf("创建飞书部门失败：%s", err.Error())
+		common.Log.Errorf("SyncFeiShuDepts: %s", errMsg)
+		return nil, err
+	}
 
+	common.Log.Infof("SyncFeiShuDepts: 飞书部门同步成功")
 	return nil, err
 }
 
@@ -43,12 +53,16 @@ func (d FeiShuLogic) addDepts(depts []*model.Group) error {
 	for _, dept := range depts {
 		err := d.AddDepts(dept)
 		if err != nil {
-			return tools.NewOperationError(fmt.Errorf("DsyncFeiShuDepts添加部门失败: %s", err.Error()))
+			errMsg := fmt.Sprintf("DsyncFeiShuDepts添加部门[%s]失败: %s", dept.GroupName, err.Error())
+			common.Log.Errorf("%s", errMsg)
+			return tools.NewOperationError(fmt.Errorf(errMsg))
 		}
 		if len(dept.Children) != 0 {
 			err = d.addDepts(dept.Children)
 			if err != nil {
-				return tools.NewOperationError(fmt.Errorf("DsyncFeiShuDepts添加部门失败: %s", err.Error()))
+				errMsg := fmt.Sprintf("DsyncFeiShuDepts添加子部门失败: %s", err.Error())
+				common.Log.Errorf("%s", errMsg)
+				return tools.NewOperationError(fmt.Errorf(errMsg))
 			}
 		}
 	}
@@ -85,27 +99,37 @@ func (d FeiShuLogic) SyncFeiShuUsers(c *gin.Context, req interface{}) (data inte
 	// 1.获取飞书用户列表
 	staffSource, err := feishu.GetAllUsers()
 	if err != nil {
-		return nil, tools.NewOperationError(fmt.Errorf("获取飞书用户列表失败：%s", err.Error()))
+		errMsg := fmt.Sprintf("获取飞书用户列表失败：%s", err.Error())
+		common.Log.Errorf("SyncFeiShuUsers: %s", errMsg)
+		return nil, tools.NewOperationError(fmt.Errorf(errMsg))
 	}
 	staffs, err := ConvertUserData(config.Conf.FeiShu.Flag, staffSource)
 	if err != nil {
-		return nil, tools.NewOperationError(fmt.Errorf("转换飞书用户数据失败：%s", err.Error()))
+		errMsg := fmt.Sprintf("转换飞书用户数据失败：%s", err.Error())
+		common.Log.Errorf("SyncFeiShuUsers: %s", errMsg)
+		return nil, tools.NewOperationError(fmt.Errorf(errMsg))
 	}
 	// 2.遍历用户，开始写入
-	for _, staff := range staffs {
+	for i, staff := range staffs {
 		// 入库
 		err = d.AddUsers(staff)
 		if err != nil {
-			return nil, tools.NewOperationError(fmt.Errorf("SyncFeiShuUsers写入用户失败：%s", err.Error()))
+			errMsg := fmt.Sprintf("写入用户[%s]失败：%s", staff.Username, err.Error())
+			common.Log.Errorf("SyncFeiShuUsers: %s", errMsg)
+			return nil, tools.NewOperationError(fmt.Errorf(errMsg))
 		}
+		common.Log.Infof("SyncFeiShuUsers: 成功同步用户[%s] (%d/%d)", staff.Username, i+1, len(staffs))
 	}
 
 	// 3.获取飞书已离职用户id列表
 	userIds, err := feishu.GetLeaveUserIds()
 	if err != nil {
-		return nil, tools.NewOperationError(fmt.Errorf("SyncFeiShuUsers获取飞书离职用户列表失败：%s", err.Error()))
+		errMsg := fmt.Sprintf("获取飞书离职用户列表失败：%s", err.Error())
+		common.Log.Errorf("SyncFeiShuUsers: %s", errMsg)
+		return nil, tools.NewOperationError(fmt.Errorf(errMsg))
 	}
 	// 4.遍历id，开始处理
+	processedCount := 0
 	for _, uid := range userIds {
 		if isql.User.Exist(
 			tools.H{
@@ -115,21 +139,30 @@ func (d FeiShuLogic) SyncFeiShuUsers(c *gin.Context, req interface{}) (data inte
 			user := new(model.User)
 			err = isql.User.Find(tools.H{"source_union_id": fmt.Sprintf("%s_%s", config.Conf.FeiShu.Flag, uid)}, user)
 			if err != nil {
-				return nil, tools.NewMySqlError(fmt.Errorf("在MySQL查询用户失败: " + err.Error()))
+				errMsg := fmt.Sprintf("在MySQL查询离职用户[%s]失败: %s", uid, err.Error())
+				common.Log.Errorf("SyncFeiShuUsers: %s", errMsg)
+				return nil, tools.NewMySqlError(fmt.Errorf(errMsg))
 			}
 			// 先从ldap删除用户
 			err = ildap.User.Delete(user.UserDN)
 			if err != nil {
-				return nil, tools.NewLdapError(fmt.Errorf("在LDAP删除用户失败" + err.Error()))
+				errMsg := fmt.Sprintf("在LDAP删除离职用户[%s]失败: %s", user.Username, err.Error())
+				common.Log.Errorf("SyncFeiShuUsers: %s", errMsg)
+				return nil, tools.NewLdapError(fmt.Errorf(errMsg))
 			}
 			// 然后更新MySQL中用户状态
 			err = isql.User.ChangeStatus(int(user.ID), 2)
 			if err != nil {
-				return nil, tools.NewMySqlError(fmt.Errorf("在MySQL更新用户状态失败: " + err.Error()))
+				errMsg := fmt.Sprintf("在MySQL更新离职用户[%s]状态失败: %s", user.Username, err.Error())
+				common.Log.Errorf("SyncFeiShuUsers: %s", errMsg)
+				return nil, tools.NewMySqlError(fmt.Errorf(errMsg))
 			}
+			processedCount++
+			common.Log.Infof("SyncFeiShuUsers: 成功处理离职用户[%s]", user.Username)
 		}
 	}
 
+	common.Log.Infof("SyncFeiShuUsers: 飞书用户同步完成，共同步%d个在职用户，处理%d个离职用户", len(staffs), processedCount)
 	return nil, nil
 }
 

--- a/logic/wecom_logic.go
+++ b/logic/wecom_logic.go
@@ -7,7 +7,7 @@ import (
 	"github.com/eryajf/go-ldap-admin/config"
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/public/client/wechat"
-
+	"github.com/eryajf/go-ldap-admin/public/common"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/ildap"
 	"github.com/eryajf/go-ldap-admin/service/isql"
@@ -22,11 +22,15 @@ func (d *WeComLogic) SyncWeComDepts(c *gin.Context, req interface{}) (data inter
 	// 1.获取所有部门
 	deptSource, err := wechat.GetAllDepts()
 	if err != nil {
-		return nil, tools.NewOperationError(fmt.Errorf("获取企业微信部门列表失败：%s", err.Error()))
+		errMsg := fmt.Sprintf("获取企业微信部门列表失败：%s", err.Error())
+		common.Log.Errorf("SyncWeComDepts: %s", errMsg)
+		return nil, tools.NewOperationError(fmt.Errorf(errMsg))
 	}
 	depts, err := ConvertDeptData(config.Conf.WeCom.Flag, deptSource)
 	if err != nil {
-		return nil, tools.NewOperationError(fmt.Errorf("转换企业微信部门数据失败：%s", err.Error()))
+		errMsg := fmt.Sprintf("转换企业微信部门数据失败：%s", err.Error())
+		common.Log.Errorf("SyncWeComDepts: %s", errMsg)
+		return nil, tools.NewOperationError(fmt.Errorf(errMsg))
 	}
 
 	// 2.将远程数据转换成树
@@ -34,7 +38,13 @@ func (d *WeComLogic) SyncWeComDepts(c *gin.Context, req interface{}) (data inter
 
 	// 3.根据树进行创建
 	err = d.addDepts(deptTree.Children)
+	if err != nil {
+		errMsg := fmt.Sprintf("创建企业微信部门失败：%s", err.Error())
+		common.Log.Errorf("SyncWeComDepts: %s", errMsg)
+		return nil, err
+	}
 
+	common.Log.Infof("SyncWeComDepts: 企业微信部门同步成功")
 	return nil, err
 }
 
@@ -43,12 +53,16 @@ func (d WeComLogic) addDepts(depts []*model.Group) error {
 	for _, dept := range depts {
 		err := d.AddDepts(dept)
 		if err != nil {
-			return tools.NewOperationError(fmt.Errorf("DsyncWeComDepts添加部门失败: %s", err.Error()))
+			errMsg := fmt.Sprintf("DsyncWeComDepts添加部门[%s]失败: %s", dept.GroupName, err.Error())
+			common.Log.Errorf("%s", errMsg)
+			return tools.NewOperationError(fmt.Errorf(errMsg))
 		}
 		if len(dept.Children) != 0 {
 			err = d.addDepts(dept.Children)
 			if err != nil {
-				return tools.NewOperationError(fmt.Errorf("DsyncWeComDepts添加部门失败: %s", err.Error()))
+				errMsg := fmt.Sprintf("DsyncWeComDepts添加子部门失败: %s", err.Error())
+				common.Log.Errorf("%s", errMsg)
+				return tools.NewOperationError(fmt.Errorf(errMsg))
 			}
 		}
 	}
@@ -85,19 +99,26 @@ func (d WeComLogic) SyncWeComUsers(c *gin.Context, req interface{}) (data interf
 	// 1.获取企业微信用户列表
 	staffSource, err := wechat.GetAllUsers()
 	if err != nil {
-		return nil, tools.NewOperationError(fmt.Errorf("获取企业微信用户列表失败：%s", err.Error()))
+		errMsg := fmt.Sprintf("获取企业微信用户列表失败：%s", err.Error())
+		common.Log.Errorf("SyncWeComUsers: %s", errMsg)
+		return nil, tools.NewOperationError(fmt.Errorf(errMsg))
 	}
 	staffs, err := ConvertUserData(config.Conf.WeCom.Flag, staffSource)
 	if err != nil {
-		return nil, tools.NewOperationError(fmt.Errorf("转换企业微信用户数据失败：%s", err.Error()))
+		errMsg := fmt.Sprintf("转换企业微信用户数据失败：%s", err.Error())
+		common.Log.Errorf("SyncWeComUsers: %s", errMsg)
+		return nil, tools.NewOperationError(fmt.Errorf(errMsg))
 	}
 	// 2.遍历用户，开始写入
-	for _, staff := range staffs {
+	for i, staff := range staffs {
 		// 入库
 		err = d.AddUsers(staff)
 		if err != nil {
-			return nil, tools.NewOperationError(fmt.Errorf("SyncWeComUsers写入用户失败：%s", err.Error()))
+			errMsg := fmt.Sprintf("写入用户[%s]失败：%s", staff.Username, err.Error())
+			common.Log.Errorf("SyncWeComUsers: %s", errMsg)
+			return nil, tools.NewOperationError(fmt.Errorf(errMsg))
 		}
+		common.Log.Infof("SyncWeComUsers: 成功同步用户[%s] (%d/%d)", staff.Username, i+1, len(staffs))
 	}
 
 	// 3.获取企业微信已离职用户id列表
@@ -106,7 +127,9 @@ func (d WeComLogic) SyncWeComUsers(c *gin.Context, req interface{}) (data interf
 	var res []*model.User
 	users, err := isql.User.ListAll()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取用户列表失败：" + err.Error()))
+		errMsg := fmt.Sprintf("获取MySQL用户列表失败：%s", err.Error())
+		common.Log.Errorf("SyncWeComUsers: %s", errMsg)
+		return nil, tools.NewMySqlError(fmt.Errorf(errMsg))
 	}
 	for _, user := range users {
 		if user.Source != config.Conf.WeCom.Flag {
@@ -124,23 +147,34 @@ func (d WeComLogic) SyncWeComUsers(c *gin.Context, req interface{}) (data interf
 		}
 	}
 	// 4.遍历id，开始处理
+	processedCount := 0
 	for _, userTmp := range res {
 		user := new(model.User)
 		err = isql.User.Find(tools.H{"source_user_id": userTmp.SourceUserId, "status": 1}, user)
 		if err != nil {
-			return nil, tools.NewMySqlError(fmt.Errorf("在MySQL查询用户失败: " + err.Error()))
+			errMsg := fmt.Sprintf("在MySQL查询离职用户[%s]失败: %s", userTmp.Username, err.Error())
+			common.Log.Errorf("SyncWeComUsers: %s", errMsg)
+			return nil, tools.NewMySqlError(fmt.Errorf(errMsg))
 		}
 		// 先从ldap删除用户
 		err = ildap.User.Delete(user.UserDN)
 		if err != nil {
-			return nil, tools.NewLdapError(fmt.Errorf("在LDAP删除用户失败" + err.Error()))
+			errMsg := fmt.Sprintf("在LDAP删除离职用户[%s]失败: %s", user.Username, err.Error())
+			common.Log.Errorf("SyncWeComUsers: %s", errMsg)
+			return nil, tools.NewLdapError(fmt.Errorf(errMsg))
 		}
 		// 然后更新MySQL中用户状态
 		err = isql.User.ChangeStatus(int(user.ID), 2)
 		if err != nil {
-			return nil, tools.NewMySqlError(fmt.Errorf("在MySQL更新用户状态失败: " + err.Error()))
+			errMsg := fmt.Sprintf("在MySQL更新离职用户[%s]状态失败: %s", user.Username, err.Error())
+			common.Log.Errorf("SyncWeComUsers: %s", errMsg)
+			return nil, tools.NewMySqlError(fmt.Errorf(errMsg))
 		}
+		processedCount++
+		common.Log.Infof("SyncWeComUsers: 成功处理离职用户[%s]", user.Username)
 	}
+	
+	common.Log.Infof("SyncWeComUsers: 企业微信用户同步完成，共同步%d个在职用户，处理%d个离职用户", len(staffs), processedCount)
 	return nil, nil
 }
 


### PR DESCRIPTION
- 添加错误消息格式化并记录详细日志
- 改进错误提示信息，包含部门名称等上下文

🐛 fix(feishu): 修复飞书部门同步的错误处理和日志记录

- 添加错误消息格式化并记录详细日志
- 改进错误提示信息，包含部门名称等上下文

🐛 fix(openldap): 修复OpenLDAP同步的错误处理和日志记录

- 添加错误消息格式化并记录详细日志
- 改进错误提示信息，包含用户和部门名称等上下文

🐛 fix(sql): 修复SQL同步的错误处理和日志记录

- 添加错误消息格式化并记录详细日志
- 改进错误提示信息，包含用户和分组名称等上下文

🐛 fix(wecom): 修复企业微信同步的错误处理和日志记录

- 添加错误消息格式化并记录详细日志
- 改进错误提示信息，包含用户和部门名称等上下文

🔧 chore(logic): 统一添加common包导入

- 在所有逻辑文件中添加common包用于日志记录

📝 docs(logic): 添加详细的同步进度日志

- 在部门同步成功时记录成功日志
- 在用户同步时添加进度跟踪日志（当前序号/总数）
- 在同步完成时统计并记录同步数量汇总信息

<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [ ] 我已阅读并理解[贡献者指南](https://github.com/eryajf/go-ldap-admin/blob/main/CONTRIBUTING.md)。
- [ ] 我已检查没有与此请求重复的拉取请求。
- [ ] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [ ] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写 PR 内容：**

-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 同步企业微信/飞书/钉钉/OpenLDAP/SQL→LDAP 时新增详细进度与完成摘要日志，包含逐用户/逐部门成功提示与统计
  - 离职用户处理增加逐条处理日志与最终汇总
- 修复
  - 统一并强化错误提示与返回，在获取、转换、写入等关键步骤失败时提供可读信息并记录
- 重构
  - 全面采用集中式日志记录，标准化错误信息格式，提升可观测性与排障效率

<!-- end of auto-generated comment: release notes by coderabbit.ai -->